### PR TITLE
Cursor setting.jsonの追加

### DIFF
--- a/config/cursor/settings.json
+++ b/config/cursor/settings.json
@@ -4,7 +4,7 @@
   "editor.wordWrap": "on",
   "editor.suggestSelection": "first",
   "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue",
-  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -javaagent:\"/Users/ryohirano/.vscode/extensions/gabrielbb.vscode-lombok-1.0.1/server/lombok.jar\"",
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m",
   "java.configuration.runtimes": [
     {
       "name": "JavaSE-11",

--- a/config/cursor/settings.json
+++ b/config/cursor/settings.json
@@ -1,0 +1,120 @@
+{
+  "editor.fontFamily": "HackGenNerd HackGen, Source Han Code JP, Ricty-Regular, Menlo, Monaco, 'Courier New', monospace",
+  "editor.fontLigatures": true,
+  "editor.wordWrap": "on",
+  "editor.suggestSelection": "first",
+  "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue",
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -javaagent:\"/Users/ryohirano/.vscode/extensions/gabrielbb.vscode-lombok-1.0.1/server/lombok.jar\"",
+  "java.configuration.runtimes": [
+    {
+      "name": "JavaSE-11",
+      "path": "/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home",
+      "default": true
+    },
+    {
+      "name": "JavaSE-17",
+      "path": "/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home"
+    }
+  ],
+  "files.exclude": {
+    "**/.classpath": true,
+    "**/.project": true,
+    "**/.settings": true,
+    "**/.factorypath": true
+  },
+  "explorer.confirmDelete": false,
+  "java.semanticHighlighting.enabled": true,
+  "explorer.confirmDragAndDrop": false,
+  "java.refactor.renameFromFileExplorer": "autoApply",
+  "editor.cursorSmoothCaretAnimation": "on",
+  "workbench.colorTheme": "GitHub Dark",
+  "workbench.editor.closeEmptyGroups": false,
+  "editor.fontSize": 14,
+  "java.format.onType.enabled": false,
+  "workbench.editor.enablePreview": false,
+  "editor.codeActionsOnSave": {},
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "sonarlint.ls.javaHome": "/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home",
+  "editor.accessibilitySupport": "off",
+  "asciidoc.use_kroki": true,
+  "java.project.importOnFirstTimeStartup": "automatic",
+  "redhat.telemetry.enabled": true,
+  "files.autoGuessEncoding": true,
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "terminal.integrated.tabs.enabled": true,
+  "vetur.dev.vlsPath": ".config/yarn/global/node_modules/vls",
+  "vetur.experimental.templateInterpolationService": true,
+  "quarkus.tools.alwaysShowWelcomePage": false,
+  "editor.tabSize": 2,
+  "bracket-pair-colorizer-2.depreciation-notice": false,
+  "liveshare.accessibility.soundsEnabled": false,
+  "go.toolsManagement.autoUpdate": true,
+  "editor.formatOnSave": true,
+  "boot-java.rewrite.reconcile": true,
+  "sonarlint.rules": {
+    "java:S2095": {
+      "level": "off"
+    },
+    "java:S1854": {
+      "level": "off"
+    }
+  },
+  "workbench.iconTheme": "material-icon-theme",
+  "accessibility.signals.lineHasError": {
+    "sound": "off"
+  },
+  "accessibility.signals.lineHasInlineSuggestion": {
+    "sound": "off"
+  },
+  "accessibility.signals.onDebugBreak": {
+    "sound": "off"
+  },
+  "accessibility.signals.noInlayHints": {
+    "sound": "off"
+  },
+  "accessibility.signals.notebookCellCompleted": {
+    "sound": "off"
+  },
+  "accessibility.signals.notebookCellFailed": {
+    "sound": "off"
+  },
+  "accessibility.signals.diffLineInserted": {
+    "sound": "off"
+  },
+  "accessibility.signals.diffLineDeleted": {
+    "sound": "off"
+  },
+  "accessibility.signals.diffLineModified": {
+    "sound": "off"
+  },
+  "accessibility.signals.progress": {
+    "sound": "off"
+  },
+  "workbench.activityBar.orientation": "vertical",
+  "diffEditor.ignoreTrimWhitespace": false,
+  "git.openRepositoryInParentFolders": "always",
+  "[dockercompose]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.autoIndent": "advanced",
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": false,
+      "strings": true
+    },
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[github-actions-workflow]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "cursor.composer.shouldChimeAfterChatFinishes": true,
+  "cursor.agent_layout_browser_beta_setting": true,
+  "git.confirmSync": false
+}

--- a/local/bin/link.sh
+++ b/local/bin/link.sh
@@ -95,9 +95,15 @@ if [[ -f "$DOTFILES_DIR/config/wezterm/wezterm.lua" ]]; then
     ln -fnsv "$DOTFILES_DIR/config/wezterm/wezterm.lua" "$XDG_CONFIG_HOME/wezterm/wezterm.lua"
 fi
 
+# Cursor configuration (macOS対応)
 if [[ -f "$DOTFILES_DIR/config/cursor/settings.json" ]]; then
-    mkdir -p "$HOME/Library/Application Support/Cursor/User/"
-    ln -fnsv "$DOTFILES_DIR/config/cursor/settings.json" "$HOME/Library/Application Support/Cursor/User/settings.json"
+    if isRunningOnMac; then
+        CURSOR_DIR="$HOME/Library/Application Support/Cursor/User"
+    else
+        CURSOR_DIR="$XDG_CONFIG_HOME/Cursor/User"
+    fi
+    mkdir -p "$CURSOR_DIR"
+    ln -fnsv "$DOTFILES_DIR/config/cursor/settings.json" "$CURSOR_DIR/settings.json"
 fi
 
 success "XDG configuration files linked"

--- a/local/bin/link.sh
+++ b/local/bin/link.sh
@@ -95,6 +95,11 @@ if [[ -f "$DOTFILES_DIR/config/wezterm/wezterm.lua" ]]; then
     ln -fnsv "$DOTFILES_DIR/config/wezterm/wezterm.lua" "$XDG_CONFIG_HOME/wezterm/wezterm.lua"
 fi
 
+if [[ -f "$DOTFILES_DIR/config/cursor/settings.json" ]]; then
+    mkdir -p "$HOME/Library/Application Support/Cursor/User/"
+    ln -fnsv "$DOTFILES_DIR/config/cursor/settings.json" "$HOME/Library/Application Support/Cursor/User/settings.json"
+fi
+
 success "XDG configuration files linked"
 
 info "linking XDG data files"


### PR DESCRIPTION
Closes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Cursor editor configuration and integrates it into the dotfiles linking workflow.
> 
> - Adds `config/cursor/settings.json` with editor preferences (fonts, ligatures, formatting, themes, language-specific formatters, Java runtime/settings)
> - Updates `local/bin/link.sh` to create the Cursor settings directory on macOS and symlink `settings.json` to `~/Library/Application Support/Cursor/User/settings.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08f4505a228defdfe266f7bf97ea1e8785014b44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->